### PR TITLE
Minimum height for content to keep footer at the bottom

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,6 +24,12 @@ body {
   color: $high-text-color;
 }
 
+// -- Min height content --
+
+.page-content {
+  min-height: calc(100vh - 180px);
+}
+
 // -- Typographie spec --
 h1.title {
   font-size: $h1;
@@ -79,3 +85,4 @@ p.body-small-strong {
   font-weight: $semi-bold;
   line-height: 20px;
 }
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,8 +10,10 @@
   </head>
 
   <body>
-    <%= render 'shared/navbar' %>
-    <%= yield %>
-    <%= render 'shared/footer' %>
+      <%= render 'shared/navbar' %>
+    <div class="page-content">
+      <%= yield %>
+    </div>
+      <%= render 'shared/footer' %>
   </body>
 </html>


### PR DESCRIPTION
Add div on yield.
Set minimum height for the yield to force the footer to stay at the bottom of the page.